### PR TITLE
Potential fix for code scanning alert no. 7: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,5 +1,8 @@
 name: lint
 
+permissions:
+  contents: read
+
 on:
   push:
     branches:


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/MPV-Player/security/code-scanning/7](https://github.com/Git-Hub-Chris/MPV-Player/security/code-scanning/7)

To fix the issue, we need to add a `permissions` block to the workflow file. This block should specify the minimal permissions required for the workflow to function correctly. Since the workflow primarily performs linting tasks, it likely only needs `contents: read` permissions. The `permissions` block can be added at the root level to apply to all jobs or to individual jobs if specific permissions are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
