### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/comment.yml
+++ b/.github/workflows/comment.yml
@@ -5,6 +5,11 @@ on:
     workflows: [build]
     types: [completed]
 
+permissions:
+  contents: read
+  pull-requests: write
+  actions: read
+
 jobs:
   pr_comment:
     if: github.event.workflow_run.event == 'pull_request' &&


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/MPV-Player/security/code-scanning/2](https://github.com/Git-Hub-Chris/MPV-Player/security/code-scanning/2)

To fix the issue, we need to add a `permissions` block to the workflow. This block should specify the minimal permissions required for the workflow to function correctly. Based on the workflow's operations, it needs `contents: read` to access repository contents, `pull-requests: write` to comment on pull requests, and possibly `actions: read` to access workflow artifacts. The `permissions` block should be added at the root level of the workflow to apply to all jobs.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
