### PR TITLE
Potential fix for code scanning alert no. 11: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,5 +1,8 @@
 name: build
 
+permissions:
+  contents: read
+
 on:
   push:
     branches:


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/MPV-Player/security/code-scanning/11](https://github.com/Git-Hub-Chris/MPV-Player/security/code-scanning/11)

To fix the issue, we need to explicitly define the permissions for the `GITHUB_TOKEN` at the workflow level or for each job. Since the workflow involves actions like `actions/upload-artifact` and `actions/cache`, the minimal permissions required are `contents: read`. If specific jobs require additional permissions (e.g., `pull-requests: write`), those can be added to the respective job blocks.

The best approach is to add a `permissions` block at the root of the workflow to apply minimal permissions (`contents: read`) to all jobs. If any job requires additional permissions, we can override the permissions at the job level.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
