### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/cleanup_caches.yml
+++ b/.github/workflows/cleanup_caches.yml
@@ -1,4 +1,7 @@
 name: Cleanup caches
+permissions:
+  contents: write
+  pull-requests: read
 
 on:
   workflow_run:


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/MPV-Player/security/code-scanning/1](https://github.com/Git-Hub-Chris/MPV-Player/security/code-scanning/1)

To fix the issue, we need to add a `permissions` block to the workflow. This block should specify the least privileges required for the workflow to function correctly. Based on the provided code, the workflow interacts with caches and pull requests, so it likely requires `contents: read` and `pull-requests: read`. If the `gh cache delete` command requires write access, we may need to include `contents: write`.

The `permissions` block should be added at the root level of the workflow file to apply to all jobs, as there is only one job (`cache`) in this workflow.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
